### PR TITLE
Be more permissive with C-g

### DIFF
--- a/espuds-input.el
+++ b/espuds-input.el
@@ -36,7 +36,8 @@
         (let ((macro (edmacro-parse-keys keybinding)))
           (if espuds-chain-active
               (setq espuds-action-chain (vconcat espuds-action-chain macro))
-            (if (equal keybinding "C-g")
+            (if (and (equal keybinding "C-g")
+                     (eq (key-binding (kbd "C-g")) 'keyboard-quit))
                 (espuds-quit)
               (execute-kbd-macro macro))))))
 


### PR DESCRIPTION
I don't know what those other commits are doing there, so my git-fu has failed me somehow. But seems like the actual changes are good.

This will allow `When I press "C-g"` to work when C-g has been rebound, by checking the key-binding of C-g before intercepting it.
