### PR TITLE
Don't use obsolete longlines-mode

### DIFF
--- a/test/espuds-test.el
+++ b/test/espuds-test.el
@@ -396,8 +396,8 @@
   (with-playground
    (with-mock
     (stub message)
-    (When "I turn on longlines-mode"))
-   (should longlines-mode)))
+    (When "I turn on abbrev-mode"))
+   (should abbrev-mode)))
 
 (ert-deftest when-i-set-variable-to-symbol-value ()
   "Should set variable to symbol value."


### PR DESCRIPTION
longlines.el has been marked as obsolete in Emacs snapshot. This commit
replaces the reference to this mode by `abbrev-mode` for the
`when-i-load-the-following` unit-test. The behavior of the mode itself
is meaningless as this test only makes sure that the mode can be
activated.
