### PR TITLE
espuds should be tested on emacs-snapshot as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - EVM_EMACS=emacs-24.1-bin
   - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
+  - EVM_EMACS=emacs-git-snapshot
 script:
   - emacs --version
   - make test


### PR DESCRIPTION
After merging 2 small pull requests (ecukes/espuds#23 and rejeep/el-mock.el#2), espuds should be able to be tested on emacs-snapshot.
