### PR TITLE
Remove dependency on noflet

### DIFF
--- a/espuds.el
+++ b/espuds.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Johan Andersson <johan.rejeep@gmail.com>
 ;; Version: 0.3.0
 ;; Keywords: test
-;; Package-Requires: ((s "1.7.0") (dash "2.2.0") (noflet "0.0.10") (f "0.12.1"))
+;; Package-Requires: ((s "1.7.0") (dash "2.2.0") (f "0.12.1"))
 ;; URL: http://github.com/ecukes/espuds
 
 ;; This file is NOT part of GNU Emacs.
@@ -35,7 +35,6 @@
 (require 'f)
 (require 's)
 (require 'dash)
-(require 'noflet)
 (require 'cl-lib)
 (require 'edmacro)
 
@@ -71,7 +70,7 @@
 
 (defun espuds-quit ()
   "Quit without signal."
-  (noflet ((signal (&rest args) nil))
+  (cl-letf (((symbol-function 'signal) #'ignore))
     (keyboard-quit)))
 
 (defun espuds-goto-line (line)

--- a/test/espuds-test.el
+++ b/test/espuds-test.el
@@ -284,10 +284,8 @@
     (should (equal (espuds-region) ""))))
 
 (ert-deftest quit ()
-  "Should quit."
-  (with-mock
-   (mock (keyboard-quit))
-   (espuds-quit)))
+  "Should quit, but should not signal."
+  (espuds-quit))
 
 (ert-deftest when-i-start-an-action-chain ()
   "Should start an action chain."


### PR DESCRIPTION
Replace `noflet` with `cl-letf` and `symbol-function` as described by [Artur Malabarba](http://endlessparentheses.com/understanding-letf-and-how-it-replaces-flet.html). 

This removes the only dependency not in melpa stable.

I also modified the unit test. The previous test would pass even if we didn't somehow block the quit signal in `espuds-quit` because it mocked `keyboard-quit`. The test now fails if the signal isn't blocked somehow. Hope that's ok.
