### PR TITLE
Make diffs slightly easier to read

### DIFF
--- a/espuds.el
+++ b/espuds.el
@@ -391,7 +391,7 @@ chain. Otherwise simulate the TYPING."
   "Asserts that the current buffer includes some text."
   (lambda (expected)
     (let ((actual (buffer-string))
-          (message "Expected '%s' to be part of '%s', but was not."))
+          (message "Expected\n%s\nto be part of:\n%s"))
       (cl-assert (s-contains? expected actual) nil message expected actual))))
 
 (Then "^I should not see\\(?: \"\\(.+\\)\"\\|:\\)$"

--- a/test/espuds-test.el
+++ b/test/espuds-test.el
@@ -569,7 +569,7 @@
    (with-mock
     (insert "foo bar baz")
     (mock
-     (error "Expected '%s' to be part of '%s', but was not." "qux" "foo bar baz"))
+     (error "Expected\n%s\nto be part of:\n%s" "qux" "foo bar baz"))
     (Then "I should see \"qux\""))))
 
 (ert-deftest then-i-should-see-when-exists-py-string ()
@@ -584,7 +584,7 @@
    (with-mock
     (insert "foo bar baz")
     (mock
-     (error "Expected '%s' to be part of '%s', but was not." "qux" "foo bar baz"))
+     (error "Expected\n%s\nto be part of:\n%s" "qux" "foo bar baz"))
     (Then "I should see:" "qux"))))
 
 (ert-deftest then-i-should-not-see-does-not-exist-arg ()


### PR DESCRIPTION
With this change the expected and actual value are aligned similarly,
making it easier to spot where the difference is.