### PR TITLE
Add tests for multiple calls to turn-on-mode

### DIFF
--- a/espuds.el
+++ b/espuds.el
@@ -323,7 +323,7 @@ chain. Otherwise simulate the TYPING."
 (When "^I turn on \\(.+\\)$"
   "Turns on some mode."
   (lambda (mode)
-    (let ((v (vconcat [?\C-u 1 ?\M-x] (string-to-vector mode))))
+    (let ((v (vconcat [?\C-u ?\M-x] (string-to-vector mode))))
       (execute-kbd-macro v))))
 
 (When "^I set \\(.+\\) to \\(.+\\)$"

--- a/test/espuds-test.el
+++ b/test/espuds-test.el
@@ -389,11 +389,27 @@
    (When "I turn on text-mode")
    (should (equal major-mode 'text-mode))))
 
+(ert-deftest when-i-turn-on-major-mode-multiple-times ()
+  "Should turn on major mode."
+  (with-playground
+   (When "I turn on c-mode")
+   (When "I turn on c-mode")
+   (should (equal major-mode 'c-mode))))
+
 (ert-deftest when-i-turn-on-minor-mode ()
   "Should turn on minor mode."
   (with-playground
    (with-mock
     (stub message)
+    (When "I turn on abbrev-mode"))
+   (should abbrev-mode)))
+
+(ert-deftest when-i-turn-on-minor-mode-multiple-times ()
+  "Should turn on (not toggle) minor mode."
+  (with-playground
+   (with-mock
+    (stub message)
+    (When "I turn on abbrev-mode")
     (When "I turn on abbrev-mode"))
    (should abbrev-mode)))
 


### PR DESCRIPTION
`when-i-turn-on-minor-mode-multiple-times` currently fails, but I don't
know why.

`when-i-turn-on-major-mode-multiple-times` is fine
