### PR TITLE
Use unwind-protect to ensure action chain is inactive afterwards

### DIFF
--- a/espuds.el
+++ b/espuds.el
@@ -279,8 +279,9 @@ The value of the face PROPERTY must be one of VALID-VALUES."
 (When "^I execute the action chain$"
   "Executes the action chain."
   (lambda ()
-    (execute-kbd-macro espuds-action-chain)
-    (setq espuds-chain-active nil)))
+    (unwind-protect
+        (execute-kbd-macro espuds-action-chain)
+      (setq espuds-chain-active nil))))
 
 (When "^I call \"\\(.+\\)\"$"
   "Call the provided COMMAND"


### PR DESCRIPTION
The step "When I execute the action chain" does not ensure the action chain is inactive afterwards when a non-local exit (error or throw) happens during execution of the action chain.

This pull-request should fix that.

I'm not yet familiar with writing ert-tests, if you think this should be explicitely tested, please help me construct the testcase.