### PR TITLE
Rename tests to avoid duplicate names.

### DIFF
--- a/test/espuds-test.el
+++ b/test/espuds-test.el
@@ -145,7 +145,7 @@
    (goto-char 3)
    (Then "the cursor should be at point \"3\"")))
 
-(ert-deftest then-the-cursor-should-be-before-is-not-before ()
+(ert-deftest then-the-cursor-should-be-before-is-not-before-1 ()
   "Should not be before word when not before."
   (with-playground
    (with-mock
@@ -196,7 +196,7 @@
    (goto-char 4)
    (Then "the cursor should be between \"foo\" and \"bar\"")))
 
-(ert-deftest then-the-cursor-should-be-before-is-not-before ()
+(ert-deftest then-the-cursor-should-be-before-is-not-before-2 ()
   "Should not be before when not before."
   (with-playground
    (with-mock


### PR DESCRIPTION
Duplicate test names will be an error in Emacs 29.