### PR TITLE
ci: Add experimental flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +23,17 @@ jobs:
           - 26.3
           - 27.2
           - 28.2
-          - snapshot
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: windows-latest
+            emacs-version: snapshot
+            experimental: true
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
There is an issue with Windows snapshot; make snapshot targets accept failure.